### PR TITLE
Loosen up dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     },
     "require": {
         "php": ">=7.4.1",
-        "opis/json-schema": "2.3.0",
-        "pcrov/jsonreader": "1.0.2",
-        "vufind-org/vufindcode": "1.2"
+        "opis/json-schema": "^2.3.0",
+        "pcrov/jsonreader": "^1.0.2",
+        "vufind-org/vufindcode": "^1.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.8.0",


### PR DESCRIPTION
While it's good to keep very specific dependency versions in the core VuFind project, it is better to use looser ones in the libraries for broader compatibility.