### PR TITLE
Ensure that the subfields key is always present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.0.2 - 2022-11-25
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Ensure that the subfields element is added to the field array when a MARCXML or
+  ISO 2709 field without subfields is unserialized.
+
 ## 1.0.1 - 2022-11-18
 
 ### Added

--- a/src/Serialization/Iso2709.php
+++ b/src/Serialization/Iso2709.php
@@ -163,7 +163,8 @@ class Iso2709 extends AbstractSerializationFile implements SerializationInterfac
                 // an indicator:
                 $newField = [
                     'ind1' => mb_substr($tagData . ' ', 0, 1, 'UTF-8'),
-                    'ind2' => mb_substr($tagData . '  ', 1, 1, 'UTF-8')
+                    'ind2' => mb_substr($tagData . '  ', 1, 1, 'UTF-8'),
+                    'subfields' => []
                 ];
                 $subfields = explode(
                     self::SUBFIELD_INDICATOR,

--- a/src/Serialization/MarcXml.php
+++ b/src/Serialization/MarcXml.php
@@ -151,7 +151,8 @@ class MarcXml extends AbstractSerializationFile implements SerializationInterfac
         foreach ($xml->datafield as $field) {
             $newField = [
                 'ind1' => str_pad((string)$field['ind1'], 1),
-                'ind2' => str_pad((string)$field['ind2'], 1)
+                'ind2' => str_pad((string)$field['ind2'], 1),
+                'subfields' => []
             ];
             foreach ($field->subfield as $subfield) {
                 $newField['subfields'][]

--- a/tests/MarcReaderTest.php
+++ b/tests/MarcReaderTest.php
@@ -163,6 +163,35 @@ class MarcReaderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test empty field in ISO2709
+     *
+     * @return void
+     */
+    public function testEmptyFieldInSO2709()
+    {
+        $marc = "00047       00037       245000200000\x1e12\x1e\x1d";
+
+        $reader = new MarcReader($marc);
+        $field = $reader->getField('245');
+        $this->assertEquals([], $reader->getSubfields($field, 'b'));
+        $this->assertEquals(
+            [
+                'leader' => '00000       00000       ',
+                'fields' => [
+                    [
+                        '245' => [
+                            'ind1' => '1',
+                            'ind2' => '2',
+                            'subfields' => []
+                        ]
+                    ]
+                ]
+            ],
+            json_decode($reader->toFormat('JSON'), true)
+        );
+    }
+
+    /**
      * Test empty subfield in ISO2709
      *
      * @return void
@@ -174,6 +203,43 @@ class MarcReaderTest extends \PHPUnit\Framework\TestCase
         $reader = new MarcReader($marc);
         $field = $reader->getField('245');
         $this->assertEquals([], $reader->getSubfields($field, 'b'));
+    }
+
+    /**
+     * Test empty field in MARCXML serialization
+     *
+     * @return void
+     */
+    public function testEmptyFieldInMarcXmlSerialization()
+    {
+        $input = <<<EOT
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <leader>00047cam a22000374i 4500</leader>
+    <datafield tag="245" ind1="1" ind2="2">
+    </datafield>
+  </record>
+</collection>
+EOT;
+
+        $reader = new MarcReader($input);
+        $field = $reader->getField('245');
+        $this->assertEquals([], $reader->getSubfields($field, 'b'));
+        $this->assertEquals(
+            [
+                'leader' => '00000cam a22000004i 4500',
+                'fields' => [
+                    [
+                        '245' => [
+                            'ind1' => '1',
+                            'ind2' => '2',
+                            'subfields' => []
+                        ]
+                    ]
+                ]
+            ],
+            json_decode($reader->toFormat('JSON'), true)
+        );
     }
 
     /**


### PR DESCRIPTION
ISO 2709 and MARCXML can contain fields without subfields, so we need to ensure that the unserialized array contains the subfields key.

Also includes new tests that failed before the changes.